### PR TITLE
Move the cleaning over

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "4.1"
+  - "5.1"
+sudo: false

--- a/src/cleaning.js
+++ b/src/cleaning.js
@@ -1,0 +1,61 @@
+import Immutable from 'immutable';
+
+/**
+ * Concatenate all "multi-line" strings if item is a list
+ * @param {Immutable.List|string} item to join
+ * @return {string} plain ol' string
+ */
+function cleanMultiline(item) {
+  return item instanceof Immutable.List ? item.join('') : item;
+}
+
+/**
+ * Concatenate all "multi-line" strings from a cell's data section
+ * @param {Immutable.Map} data display data possibly in need of cleaning
+ * @return {Immutable.Map} display data without multi-line strings
+ */
+function cleanMultilineOutputData(data) {
+  // If data is undefined, we just return it back
+  return data ? data.map(cleanMultiline) : data;
+}
+
+/**
+ * Concatenate all "multi-line" strings from a cell's outputs
+ * @param {Immutable.Map} outputs a cell's outputs
+ * @return {Immutable.Map} cell outputs without multi-line strings
+ */
+function cleanMultilineOutputs(outputs) {
+  // If outputs is undefined, we just return it back
+  return outputs ? outputs.map(output => {
+    return output.update('text', cleanMultiline)
+                 .update('data', cleanMultilineOutputData);
+  }) : outputs;
+}
+
+/**
+ * Concatenate all "multi-line" strings from a cell (on disk -> in-mem format)
+ * @param {Immutable.Map} cell the cell to clean up
+ * @return {Immutable.Map} cell without multi-line strings
+ */
+function cleanMultilineCell(cell) {
+  return cell.update('source', cleanMultiline)
+             .update('outputs', cleanMultilineOutputs);
+}
+
+/**
+ * Concatenate all "multi-line" strings from a cell
+ * @param {Immutable.List} cells the cell to clean up
+ * @return {Immutable.Map} cell without multi-line strings
+ */
+function cleanMultilineCells(cells) {
+  return cells.map(cleanMultilineCell);
+}
+
+/**
+ * Concatenate all "multi-line" strings from a notebook (on disk format -> in-memory)
+ * @param {Immutable.Map} nb notebook
+ * @return {Immutable.Map} notebook without multi-line strings
+ */
+export function cleanMultilines(nb) {
+  return nb.update('cells', cleanMultilineCells);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,49 +1,8 @@
 import Immutable from 'immutable';
 
-function cleanMultiline(item) {
-  if (item instanceof Immutable.List) {
-    return item.join('');
-  }
-  return item;
-}
-
-function demultilineOutputData(data) {
-  // If data is undefined, we just return it back
-  return data ? data.map(cleanMultiline) : data;
-}
-
-function demultilineOutputs(outputs) {
-  // If outputs is undefined, we just return it back
-  return outputs ? outputs.map(output => {
-    return output.update('text', cleanMultiline)
-                 .update('data', demultilineOutputData);
-  }) : outputs;
-}
-
-/**
- * Concatenate all "multi-line" strings from a cell (on disk -> in-mem format)
- * @param {Immutable.Map} cell the cell to clean up
- * @return {Immutable.Map} cell without multi-line strings
- */
-function demultilineCell(cell) {
-  return cell.update('source', cleanMultiline)
-             .update('outputs', demultilineOutputs);
-}
-
-function demultilineCells(cells) {
-  return cells.map(demultilineCell);
-}
-
-/**
- * Trims all "multi-line" strings from a notebook (on disk format -> in-memory)
- * @param {commutable.Notebook} nb notebook
- * @return {commutable.Notebook} notebook without multi-line strings
- */
-function demultilineNotebook(nb) {
-  return nb.update('cells', demultilineCells);
-}
+import { cleanMultilines } from './cleaning';
 
 export function fromJS(notebookJSON) {
   const immnb = Immutable.fromJS(notebookJSON);
-  return demultilineNotebook(immnb);
+  return cleanMultilines(immnb);
 }


### PR DESCRIPTION
Keeping those scopes separate, commenting things well. Name changes are all internal, non-exported functions. One new function is exported, `cleanMultilines`, that accepts a Notebook that is an `Immutable.Map`.