### PR TITLE
Require the Cell ID to be passed in

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,12 @@ export function toJS(notebook) {
 
 /**
  * Create a new Notebook
- * @param {language_info} language_info the language info for the document
- * @param {language_info.file_extension} the file extension for the language
- * @param {language_info.mimetype} the mimetype for the language
- * @param {language_info.name} nice name of the language
- * @param {language_info.version} version of the language
+ * @param {Object} language_info the language info for the document
+ * @param {string} language_info.file_extension the file extension for the language
+ * @param {string} language_info.mimetype the mimetype for the language
+ * @param {string} language_info.name nice name of the language
+ * @param {string} language_info.version version of the language
+ * @return {Immutable.Map} notebook document
  */
 export function Notebook(language_info) {
   return fromJS({
@@ -63,15 +64,16 @@ export const emptyCodeCell = Immutable.fromJS({
   'outputs': [],
 });
 
-export function insertCellAt(notebook, cell, index) {
-  const cellID = uuid();
+export function insertCellAt(notebook, cell, cellID, index) {
   return notebook.setIn(['cellMap', cellID], cell)
                  .set('cellOrder',
                   notebook.get('cellOrder').splice(index, 0, cellID));
 }
 
-export function appendCell(notebook, cell) {
-  const cellID = uuid();
+export function appendCell(notebook, cell, cellID) {
+  if(!cellID) {
+    cellID = uuid();
+  }
   return notebook.setIn(['cellMap', cellID], cell)
                  .set('cellOrder',
                   notebook.get('cellOrder').push(cellID));


### PR DESCRIPTION
We noticed in nteract/nteract that we tend to want to know the ID after insertion
which either means that we pass the cell ID in or we change the return type for some functions.
This opts to pass the cell ID after.

Either way, we're going to have to release a major version since we're changing the call signatures.

Before we :ship: it though, we'll want to bring in some other utility functions that were written in
nteract and bring them to commutable.