### PR TITLE
Trim out dependencies that should only be devDeps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "parser": "babel-eslint",
+  "extends": "airbnb",
+  "env": {
+    "browser": true,
+    "node": true,
+    "mocha": true
+  },
+  "rules": {
+      "camelcase": [0],
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install --save commutable
 ### Fresh notebook
 
 ```js
-> const uuid = require('node-uuid').v4
+> const uuid = require('uuid').v4
 undefined
 > const commutable = require('.')
 undefined

--- a/package.json
+++ b/package.json
@@ -24,10 +24,6 @@
   },
   "homepage": "https://github.com/nteract/commutable#readme",
   "dependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
-    "chai-immutable": "^1.5.4",
     "immutable": "^3.7.6",
     "lodash.repeat": "^4.0.0",
     "node-uuid": "^1.4.7"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "immutable": "^3.7.6",
     "lodash.repeat": "^4.0.0",
-    "node-uuid": "^1.4.7"
+    "uuid": "^2.0.2"
   },
   "babel": {
     "presets": [
@@ -36,13 +36,17 @@
   "devDependencies": {
     "babel-cli": "^6.4.0",
     "babel-core": "^6.4.0",
-    "babel-eslint": "^4.1.6",
+    "babel-eslint": "^6.0.4",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",
     "chai-immutable": "^1.5.3",
     "chalk": "^1.1.1",
-    "eslint": "^1.10.3",
+    "eslint": "^2.10.1",
+    "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-import": "^1.8.0",
+    "eslint-plugin-jsx-a11y": "^1.2.0",
+    "eslint-plugin-react": "^5.1.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.4",
     "notebook-test-data": "0.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 
 import { cleanMultilineNotebook, makeMultilineNotebook } from './cleaning';
-import { v4 as uuid } from 'node-uuid';
+import { v4 as uuid } from 'uuid';
 import { upgrade } from './convert';
 export { upgrade };
 

--- a/test/commutable_spec.js
+++ b/test/commutable_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { v4 as uuid } from 'node-uuid';
+import { v4 as uuid } from 'uuid';
 
 import Immutable from 'immutable';
 


### PR DESCRIPTION
When looking at deps here I noticed there were dependencies in here that should only be in devDeps.

We also need to migrate this package from `node-uuid` to `uuid`, per https://github.com/broofa/node-uuid/issues/116