### PR TITLE
cleanMultiline accepts string or List<string>

### DIFF
--- a/src/cleaning.ts
+++ b/src/cleaning.ts
@@ -8,7 +8,7 @@ import {
  * @return {string} plain ol' string
  */
 function cleanMultiline(item : (List<string> | string)) {
-  return item ? item.join('') : item;
+  return item instanceof List ? item.join('') : item;
 }
 
 /**

--- a/src/cleaning.ts
+++ b/src/cleaning.ts
@@ -52,7 +52,7 @@ function processOutputs(processor, outputs : Map<string, any>) {
   // If outputs is undefined, we just return it back
   return outputs ? outputs.map(output =>
     output.update('text', processor)
-          .update('data', processOutputData.bind(this, processor))
+          .update('data', processOutputData.bind(null, processor))
   ) : outputs;
 }
 
@@ -64,7 +64,7 @@ function processOutputs(processor, outputs : Map<string, any>) {
  */
 function processCell(processor, cell : Map<string, any>) {
   return cell.update('source', processor)
-             .update('outputs', processOutputs.bind(this, processor));
+             .update('outputs', processOutputs.bind(null, processor));
 }
 
 /**
@@ -74,7 +74,7 @@ function processCell(processor, cell : Map<string, any>) {
  * @return {Map} cell without multi-line strings
  */
 function processCells(processor, cells : List<Map<string, any>>) {
-  return cells.map(processCell.bind(this, processor));
+  return cells.map(processCell.bind(null, processor));
 }
 
 /**
@@ -83,7 +83,7 @@ function processCells(processor, cells : List<Map<string, any>>) {
  * @return {Map} notebook without multi-line strings
  */
 export function cleanMultilineNotebook(nb : Map<string, any>) {
-  return nb.update('cells', processCells.bind(this, cleanMultiline));
+  return nb.update('cells', processCells.bind(null, cleanMultiline));
 }
 
 
@@ -94,7 +94,7 @@ export function cleanMultilineNotebook(nb : Map<string, any>) {
  * @return {Map} nb
  */
 export function makeMultilineNotebook(nb : Map<string, any>) {
-  return nb.update('cells', processCells.bind(this, breakIntoMultiline));
+  return nb.update('cells', processCells.bind(null, breakIntoMultiline));
 }
 
 /**

--- a/src/cleaning.ts
+++ b/src/cleaning.ts
@@ -2,13 +2,23 @@ import {
   List,
   Map,
 } from 'immutable';
+
 /**
  * Concatenate all "multi-line" strings if item is a list
  * @param {List|string} item to join
  * @return {string} plain ol' string
  */
-function cleanMultiline(item : (List<string> | string)) {
-  return item instanceof List ? item.join('') : item;
+function cleanMultiline(item : List<string> | string) {
+  if (typeof item === 'string') {
+    return item;
+  }
+  else if (item instanceof List) {
+    return item.join('');
+  }
+  else if (item === undefined){
+    return '';
+  }
+  throw new Error(`Expected immutable.List or string, got ${item}`);
 }
 
 /**

--- a/src/cleaning.ts
+++ b/src/cleaning.ts
@@ -7,7 +7,7 @@ import {
  * @param {List|string} item to join
  * @return {string} plain ol' string
  */
-function cleanMultiline(item : List<string>) {
+function cleanMultiline(item : (List<string> | string)) {
   return item ? item.join('') : item;
 }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "declaration": true,
-        "noEmitOnError": true,
         "moduleResolution": "node",
         "target": "ES5",
         "outDir": "../lib"


### PR DESCRIPTION
When it's a string, it needs to pass it on through. When an `Immutable.List`, it needs to join the strings and return them. This is part of the notebook format that they can be in either format.

We'll need to make a patch release after this.