### PR TITLE
Update nbformat_minor version

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -21,7 +21,7 @@ const upgraders = {
     return nb 
       .setIn(['metadata', 'orig_nbformat'], nb.getIn(['metadata', 'orig_nbformat'], 3))
       .set('nbformat', 4)
-      .set('nbformat_minor', 0)
+      .set('nbformat_minor', 1)
       .set('cells', nb
         .get('worksheets')
         .reduce((a, b) => a.concat(b.get('cells')), List<Map<string, any>>())


### PR DESCRIPTION
This addresses an annoying issue when opening notebooks created in nteract in Jupyter notebook. The notebooks are opened as read-only in Jupyter and there is no way to edit and save them. Upon further inspection, it appears the issue is related to the out of date version of `nbformat_minor` that commutable enforces. We'll need to make sure that our versioning is most up to date with whatever Jupyter is using.